### PR TITLE
fix(itemPage): Suppression d'importation inutile dans itemPage.tsx

### DIFF
--- a/app/src/pages/itemPage.tsx
+++ b/app/src/pages/itemPage.tsx
@@ -1,6 +1,6 @@
 import axios from "axios"
 import { FC, useEffect, useState } from "react"
-import { Navigate, useNavigate, useParams } from "react-router"
+import { useNavigate, useParams } from "react-router"
 import { ItemProps } from "../@interface/ItemProps"
 
 import '../styles/item.scss'


### PR DESCRIPTION
- Retrait de l'importation de `Navigate` qui n'était pas utilisée dans le fichier itemPage.tsx, contribuant ainsi à un code plus propre et plus lisible.