### PR TITLE
:wrench: enable Swagger UI only in development; update README (Supaba…

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -7,10 +7,15 @@ const cookieParser = require("cookie-parser");
 const path = require("path");
 
 const allowedOrigins = [
-  "https://collections-seven-iota.vercel.app",
+  //dev
+  "http://localhost:5173",
   "http://192.168.1.181:5173",
   "http://localhost:5173",
+  "http://partagetacollection.local:5173",
   "http://127.0.0.1:5173",
+
+  // prod
+  "https://collections-seven-iota.vercel.app",
 ];
 
 const corsOptions = {
@@ -45,13 +50,14 @@ app.use(express.urlencoded({ limit: "50mb", extended: true }));
 
 app.use("/api/uploads", express.static(path.join(__dirname, "uploads")));
 
-// Swagger après CORS
-// const swaggerUi = require("swagger-ui-express");
-// const swaggerDocument = require("./swagger-output.json");
-// app.use("/swagger", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+// Swagger (uniquement en développement)
+if (process.env.NODE_ENV === "development") {
+  const swaggerUi = require("swagger-ui-express");
+  const swaggerDocument = require("./swagger-output.json");
+  app.use("/swagger", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+}
 
 app.use(routes);
 app.listen(port, () => {
   console.log(`App listening on port ${port}`);
-
 });

--- a/api/swagger-output.json
+++ b/api/swagger-output.json
@@ -5,13 +5,23 @@
     "description": "Documentation de l'API pour Collectify",
     "version": "1.0.0"
   },
-  "host": "192.168.1.181:3001",
-  "basePath": "/",
+  "host": "collections-7o06.onrender.com",
+  "basePath": "/api",
   "schemes": [
-    "http"
+    "https"
   ],
   "paths": {
-    "/signin": {
+    "/api": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/auth/signin": {
       "post": {
         "description": "",
         "parameters": [
@@ -22,10 +32,10 @@
               "type": "object",
               "properties": {
                 "email": {
-                  "example": "john.doe@email.com"
+                  "example": "any"
                 },
                 "password": {
-                  "example": "MonSuperMotDePasse1541!!"
+                  "example": "any"
                 }
               }
             }
@@ -35,73 +45,71 @@
           "200": {
             "description": "OK"
           },
-          "401": {
-            "description": "Bad combinaison email / password"
-          }
-        }
-      }
-    },
-    "/signup": {
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "email": {
-                  "example": "any"
-                },
-                "password": {
-                  "example": "any"
-                },
-                "username": {
-                  "example": "any"
-                },
-                "passwordConfirmation": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/logout": {
-      "post": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "cookie",
-            "in": "header",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/user-collection": {
-      "get": {
-        "description": "",
-        "responses": {
+          "400": {
+            "description": "Bad Request"
+          },
           "401": {
             "description": "Unauthorized"
           }
         }
       }
     },
-    "/user-collection/{id}": {
+    "/api/auth/signup": {
+      "post": {
+        "description": "",
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/collection-status/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/item/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/item/{id}": {
       "get": {
         "description": "",
         "parameters": [
@@ -118,11 +126,39 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
       }
     },
-    "/create": {
+    "/api/item/create": {
       "post": {
         "description": "",
         "parameters": [
@@ -155,12 +191,237 @@
         }
       }
     },
-    "/image/create": {
+    "/api/collection/{id}/items": {
+      "patch": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/collection/user-collection": {
       "get": {
         "description": "",
         "responses": {
           "401": {
             "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/collection/user-collection/{id}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/collection/create": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "newCollection": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/collection/{id}/delete": {
+      "delete": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/format-type/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/user/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/condition/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/api/collection-item/": {
+      "post": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/collection-item/{id}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/collection-item/collection-item": {
+      "post": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
       }

--- a/app/src/styles/_vars.scss
+++ b/app/src/styles/_vars.scss
@@ -7,4 +7,4 @@ $button-bg-color-danger-hover: rgb(187, 3, 3);
 $button-bg-color-hover:  rgb(233, 129, 2);
 $background-color-dark : #14141b;
 $background-color-logo-colorized : #fef9f2;
-
+$text-color: #111827;

--- a/app/src/styles/header.scss
+++ b/app/src/styles/header.scss
@@ -9,7 +9,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  border-bottom: .1px solid rgb(114, 92, 18);
+  border-bottom: .1px solid #e5e7eb;
   &__nav {    
     display: flex;
     height: 3rem;

--- a/app/src/styles/signin.scss
+++ b/app/src/styles/signin.scss
@@ -1,16 +1,16 @@
 @use "./mixins";
 
 .signin {
-    max-height: calc(100% - 4rem);
-    width: 100%;
+   
+
     display: flex;
-    justify-content: center;
-    align-items: center;
     margin: auto;
     &__container {
-      width: 100%;
+      width: 420px;
       padding: 1rem;
-      text-align: center;    
+      text-align: center;   
+      border: 1px solid #e5e7eb; 
+      border-radius: 15px;
     }
     &__title > h2 {
       text-align: center;

--- a/app/src/styles/signup.scss
+++ b/app/src/styles/signup.scss
@@ -1,15 +1,14 @@
 @use"./mixins";
 
 .signup {
-  height: calc(100vh - 4rem);
   display: flex;
-  justify-content: center;
-  align-items: center;
   margin: auto;
   &__container {
-    width: 100%;  
+    width: 420px;
     padding: 1rem;
     text-align: center;
+    border: 1px solid #e5e7eb; 
+      border-radius: 15px;
   }
   &__title > h2 {
     text-align: center;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING=true
       - PORT=3001
+     
     networks:
       - collectify
 networks:


### PR DESCRIPTION
…se, Vercel/VPS, environments)

- Mount Swagger route only when NODE_ENV=development in api/server.js
- Replace Cloudinary with Supabase (PostgreSQL + Storage)
- Clarify deployment: frontend on Vercel, backend on VPS (Docker)
- Add environment variable examples for API/App (SUPABASE_URL, SERVICE_ROLE_KEY, BUCKET, VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY)
- Add an “Environments” section (no URLs)
- Update Troubleshooting with Supabase Storage and CORS notes

:art: impove css